### PR TITLE
Fix ExitStatus import for non-Windows builds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,11 @@
 use dialoguer::{theme::ColorfulTheme, Select, Input};
-use std::os::windows::process::ExitStatusExt;
 use std::process::Command;
+#[cfg(test)]
 use std::process::Output;
+#[cfg(all(test, unix))]
+use std::os::unix::process::ExitStatusExt;
+#[cfg(all(test, windows))]
+use std::os::windows::process::ExitStatusExt;
 
 /// Main entry point for UniShell - Git Operations Terminal
 fn main() {


### PR DESCRIPTION
## Summary
- scope ExitStatusExt/Output imports to tests
- support both Unix and Windows in tests

## Testing
- `cargo build --quiet`
- `cargo test --quiet`